### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "babel-react-hmre",
+  "name": "babel-preset-react-hmre",
   "version": "0.0.0",
   "description": "Babel preset for React HMR and Error Catching",
   "main": "index.js",


### PR DESCRIPTION
Without this name change, babel doesn't seem to pick it up properly by name:
```
{
	"presets": ["react", "react-hmre"]
}
```